### PR TITLE
correct parse values shorter than number of decimals

### DIFF
--- a/overpunch/__init__.py
+++ b/overpunch/__init__.py
@@ -53,6 +53,8 @@ def extract(raw, decimals=2):
 
     """
 
+    raw = raw.zfill(decimals)
+
     length = len(raw)
     last_char = raw[length - 1]
     (sign, cent) = EXTRACT_REF[last_char]

--- a/overpunch/tests/test_overpunch.py
+++ b/overpunch/tests/test_overpunch.py
@@ -26,6 +26,10 @@ class TestCase(unittest.TestCase):
         d = Decimal("-12.3450")
         self.assertEquals(overpunch.extract("12345}", decimals=4), d)
 
+    def test_extract_4_decimal_unpadded(self):
+        d = Decimal("0.0005")
+        self.assertEquals(overpunch.extract("N", decimals=4), d)
+
     def test_extract_0_decimal_negative(self):
         d = Decimal("-123450")
         self.assertEquals(overpunch.extract("12345}", decimals=0), d)


### PR DESCRIPTION
before:
```
>>> overpunch.extract("N", decimals=3)
Decimal('-0.5')
```

after:
```
>>> overpunch.extract("N", decimals=3)
Decimal('-0.005')
```